### PR TITLE
Add script to automatically remove accepted ontologies

### DIFF
--- a/.github/workflows/purge.yml
+++ b/.github/workflows/purge.yml
@@ -1,4 +1,4 @@
-name: Remove accepted ontologies
+name: Remove Accepted Ontologies
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/purge.yml
+++ b/.github/workflows/purge.yml
@@ -1,0 +1,37 @@
+name: Remove accepted ontologies
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"  # once per day
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+        with:
+          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
+          fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install --upgrade setuptools wheel
+          pip install tox
+      - name: Update
+        run: |
+          tox -e purge
+      - name: Commit files
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add --all
+          git commit -m "Automatically remove accepted ontologies" -a
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -1,9 +1,21 @@
-# Repo to manage the OBO Foundry Dashboard for New Ontology Requests
+# Repo to manage the OBO Foundry Dashboard for New Ontology Requests (NORs)
 
 Page deployed at: https://obofoundry.github.io/obo-nor.github.io/
 
-To update:
+## Update
 
 1. change `dashboard-config.yml`
 2. run `sh run-dash.sh`
 
+## Remove accepted ontologies
+
+After ontologies have been accepted into the OBO Foundry, they will be displayed on the
+main [OBO Dashboard](https://dashboard.obofoundry.org/) and can be safely removed from the NOR dashboard. This is
+automated with the following code:
+
+```shell
+pip install tox
+tox -e purge
+```
+
+This is also automatically run nightly via GitHub Actions. [![Remove Accepted Ontologies](https://github.com/OBOFoundry/obo-nor.github.io/actions/workflows/purge.yml/badge.svg)](https://github.com/OBOFoundry/obo-nor.github.io/actions/workflows/purge.yml)

--- a/scripts/purge.py
+++ b/scripts/purge.py
@@ -1,0 +1,44 @@
+"""Purge accepted ontologies from NOR Dashboard."""
+
+from pathlib import Path
+
+import click
+import requests
+import yaml
+
+HERE = Path(__file__).parent.resolve()
+ROOT = HERE.parent.resolve()
+DASHBOARD_DIRECTORY = ROOT.joinpath("dashboard")
+DASHBOARD_CONFIG_PATH = ROOT.joinpath("dashboard-config.yml")
+
+URL = "https://raw.githubusercontent.com/OBOFoundry/OBOFoundry.github.io/master/registry/ontologies.yml"
+
+
+@click.command()
+def main():
+    """Purge accepted ontologies from NOR Dashboard."""
+    #: A set of prefixes for active ontologies in the OBO Foundry
+    prefixes = {
+        record["id"]
+        for record in yaml.safe_load(requests.get(URL).content)["ontologies"]
+        if record["activity_status"] in {"active"}
+    }
+
+    # Remove folders corresponding to active ontologies
+    for directory in DASHBOARD_DIRECTORY.iterdir():
+        if directory.is_dir() and directory.name in prefixes:
+            for path in directory.iterdir():
+                click.echo(f"removing file: {path}")
+                path.unlink()
+            click.echo(f"removing directory: {directory}")
+            directory.rmdir()
+
+    # Remove configuration corresponding to active ontologies
+    config = yaml.safe_load(DASHBOARD_CONFIG_PATH.read_text())
+    config["ontologies"]["custom"] = [
+        row for row in config["ontologies"]["custom"] if row["id"] not in prefixes
+    ]
+
+
+if __name__ == "__main__":
+    main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,22 @@
+[tox]
+envlist =
+    lint
+    purge
+
+[testenv:purge]
+skip_install = true
+deps =
+    click
+    requests
+    pyyaml
+commands =
+    python scripts/purge.py
+
+[testenv:lint]
+skip_install = true
+deps =
+    black
+    isort
+commands =
+    isort --profile=black .
+    black .


### PR DESCRIPTION
Closes #22

This PR does the following:

1. Adds a Python script that automatically removes accepted ontologies from the NOR dashboard.
2. Adds a `tox` file with appropriate configuration to run this script reproducibly
3. Adds a GitHub Actions workflow to automate running this script nightly or on request (though it's TBD how well this works with deleting files)
4. Updates the README with some information on this

After accepting this and running the script via GitHub Actions, the T4FS ontology should get removed.

This took about 15 minutes to write ;) 